### PR TITLE
Loom validator

### DIFF
--- a/src/utils/CreatorTokenTransferValidator.sol
+++ b/src/utils/CreatorTokenTransferValidator.sol
@@ -1748,7 +1748,7 @@ contract CreatorTokenTransferValidator is IEOARegistry, ITransferValidator, ERC1
         address from, 
         address to,
         uint256 tokenId
-    ) internal view returns (bytes4,uint16) {
+    ) internal view virtual returns (bytes4,uint16) {
         if (caller == address(this)) { 
             // If the caller is self (Permit-C Processor) it means we have already applied operator validation in the 
             // _beforeTransferFrom callback.  In this case, the security policy was already applied and the operator

--- a/src/utils/LoomValidator.sol
+++ b/src/utils/LoomValidator.sol
@@ -37,36 +37,8 @@ contract LoomValidator is CreatorTokenTransferValidator {
     using EnumerableSet for EnumerableSet.AddressSet;
     uint16 private constant DEFAULT_TOKEN_TYPE = 0;
 
-    /*************************************************************************/
-    /*                             CUSTOM ERRORS                             */
-    /*************************************************************************/
-
-    /// @dev Thrown when attempting to call a function that requires owner or default admin role for a collection that the caller does not have.
-    error LoomValidator__CallerMustHaveElevatedPermissionsForSpecifiedNFT();
-
-    /// @dev Thrown when attempting to add a zero address to the to whitelist.
-    error LoomValidator__CannotAddZeroAddressToToWhitelist();
-
-    /*************************************************************************/
-    /*                                EVENTS                                 */
-    /*************************************************************************/
-
-    /// @dev Emitted when an address is added to the to whitelist for a collection.
-    event AddedToWhitelistForCollection(address indexed collection, address indexed toAddress);
-
-    /// @dev Emitted when an address is removed from the to whitelist for a collection.
-    event RemovedFromToWhitelistForCollection(address indexed collection, address indexed toAddress);
-
-    /*************************************************************************/
-    /*                                STORAGE                                */
-    /*************************************************************************/
-
     /// @dev Mapping of collection addresses to their to whitelist settings
     mapping(uint120 => List) internal targetWhitelist;
-
-    /*************************************************************************/
-    /*                             CONSTRUCTOR                               */
-    /*************************************************************************/
 
     constructor(
         address defaultOwner,

--- a/src/utils/LoomValidator.sol
+++ b/src/utils/LoomValidator.sol
@@ -37,8 +37,8 @@ contract LoomValidator is CreatorTokenTransferValidator {
     using EnumerableSet for EnumerableSet.AddressSet;
     uint16 private constant DEFAULT_TOKEN_TYPE = 0;
 
-    /// @dev Mapping of collection addresses to their to whitelist settings
-    mapping(uint120 => List) internal targetWhitelist;
+    /// @dev Mapping of list ids to recipient allowlists.
+    mapping(uint120 => List) internal recipientAllowlist;
 
     constructor(
         address defaultOwner,
@@ -55,7 +55,7 @@ contract LoomValidator is CreatorTokenTransferValidator {
     ) {}
 
     /**
-     * @notice Adds one or more accounts to a targetWhitelist.
+     * @notice Adds one or more accounts to a recipientAllowlist.
      *
      * @dev Throws when the caller does not own the specified list.
      * @dev Throws when the accounts array is empty.
@@ -67,8 +67,8 @@ contract LoomValidator is CreatorTokenTransferValidator {
      * @param id       The id of the list.
      * @param accounts The addresses of the accounts to add.
      */
-    function addAccountsToTargetWhitelist(uint120 id, address[] calldata accounts) external {
-        _addAccountsToList(targetWhitelist[id], LIST_TYPE_TARGET_WHITELIST, id, accounts);
+    function addAccountsToRecipientAllowlist(uint120 id, address[] calldata accounts) external {
+        _addAccountsToList(recipientAllowlist[id], LIST_TYPE_TARGET_WHITELIST, id, accounts);
     }
 
         /**
@@ -84,11 +84,11 @@ contract LoomValidator is CreatorTokenTransferValidator {
      * @param id       The id of the list.
      * @param accounts The addresses of the accounts to remove.
      */
-    function removeAccountsToTargetWhitelist(
+    function removeAccountsToRecipientAllowlist(
         uint120 id,
         address[] calldata accounts
     ) external {
-        _removeAccountsFromList(targetWhitelist[id], LIST_TYPE_TARGET_WHITELIST, id, accounts);
+        _removeAccountsFromList(recipientAllowlist[id], LIST_TYPE_TARGET_WHITELIST, id, accounts);
     }
 
     /**
@@ -96,8 +96,8 @@ contract LoomValidator is CreatorTokenTransferValidator {
      * @param  id The id of the list.
      * @return An array of whitelisted accounts.
      */
-    function getTargetWhitelistedAccounts(uint120 id) public view returns (address[] memory) {
-        return targetWhitelist[id].enumerableAccounts.values();
+    function getRecipientAllowlistedAccounts(uint120 id) public view returns (address[] memory) {
+        return recipientAllowlist[id].enumerableAccounts.values();
     }
 
     /**
@@ -106,8 +106,8 @@ contract LoomValidator is CreatorTokenTransferValidator {
      * @param account  The address of the account to check.
      * @return         True if the account is whitelisted in the specified list, false otherwise.
      */
-    function isAccountTargetWhitelisted(uint120 id, address account) public view returns (bool) {
-        return targetWhitelist[id].nonEnumerableAccounts[account];
+    function isAccountRecipientAllowlisted(uint120 id, address account) public view returns (bool) {
+        return recipientAllowlist[id].nonEnumerableAccounts[account];
     }
 
     /*************************************************************************/
@@ -163,9 +163,9 @@ contract LoomValidator is CreatorTokenTransferValidator {
 
         CollectionSecurityPolicyV3 storage collectionSecurityPolicy = collectionSecurityPolicies[collection];
         uint120 listId = collectionSecurityPolicy.listId;
-        List storage targetWhitelist = targetWhitelist[listId];
-        // If the 'to' address is on the toWhitelist for this collection, bypass validation
-        if (targetWhitelist.nonEnumerableAccounts[to]) {
+        List storage recipientAllowlist = recipientAllowlist[listId];
+        // If the 'to' address is on the recipientAllowlist for this collection, bypass validation
+        if (recipientAllowlist.nonEnumerableAccounts[to]) {
             return (SELECTOR_NO_ERROR, DEFAULT_TOKEN_TYPE);
         }
 

--- a/src/utils/LoomValidator.sol
+++ b/src/utils/LoomValidator.sol
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "./CreatorTokenTransferValidator.sol";
+
+uint8 constant LIST_TYPE_TARGET_WHITELIST = 3;
+
+/**
+ * @title  LoomValidator
+ * @author Abraxas
+ * @notice The LoomValidator contract extends CreatorTokenTransferValidator to provide an additional
+ *         "to whitelist" feature that allows certain addresses to bypass transfer validation entirely.
+ *         This is useful for scenarios where specific addresses (like protocol contracts or bridges)
+ *         should be able to receive tokens without any transfer restrictions.
+ *
+ * @dev    <h4>Additional Features</h4>
+ *         - ToWhitelist: Allows collections to whitelist specific addresses that can receive tokens
+ *           without any transfer validation being applied.
+ *         - Bypass validation: When the 'to' address is on the toWhitelist, the _validateTransfer
+ *           function is completely skipped, allowing unrestricted transfers to those addresses.
+ *
+ * @dev    <h4>Benefits</h4>
+ *         - Protocol integration: Enables seamless integration with other protocols and bridges
+ *           that may need to receive tokens without transfer restrictions.
+ *         - Flexible security: Maintains all existing security features while providing escape hatches
+ *           for trusted addresses.
+ *         - Gas optimization: Bypasses validation entirely for whitelisted receivers, saving gas.
+ *
+ * @dev    <h4>Use Cases</h4>
+ *         - Cross-chain bridges that need to receive tokens for bridging
+ *         - Protocol contracts that manage token staking or lending
+ *         - Marketplace contracts that need to hold tokens during sales
+ *         - Emergency rescue contracts for token recovery
+ */
+
+contract LoomValidator is CreatorTokenTransferValidator {
+    using EnumerableSet for EnumerableSet.AddressSet;
+    uint16 private constant DEFAULT_TOKEN_TYPE = 0;
+
+    /*************************************************************************/
+    /*                             CUSTOM ERRORS                             */
+    /*************************************************************************/
+
+    /// @dev Thrown when attempting to call a function that requires owner or default admin role for a collection that the caller does not have.
+    error LoomValidator__CallerMustHaveElevatedPermissionsForSpecifiedNFT();
+
+    /// @dev Thrown when attempting to add a zero address to the to whitelist.
+    error LoomValidator__CannotAddZeroAddressToToWhitelist();
+
+    /*************************************************************************/
+    /*                                EVENTS                                 */
+    /*************************************************************************/
+
+    /// @dev Emitted when an address is added to the to whitelist for a collection.
+    event AddedToWhitelistForCollection(address indexed collection, address indexed toAddress);
+
+    /// @dev Emitted when an address is removed from the to whitelist for a collection.
+    event RemovedFromToWhitelistForCollection(address indexed collection, address indexed toAddress);
+
+    /*************************************************************************/
+    /*                                STORAGE                                */
+    /*************************************************************************/
+
+    /// @dev Mapping of collection addresses to their to whitelist settings
+    mapping(uint120 => List) internal targetWhitelist;
+
+    /*************************************************************************/
+    /*                             CONSTRUCTOR                               */
+    /*************************************************************************/
+
+    constructor(
+        address defaultOwner,
+        address eoaRegistry_,
+        string memory name,
+        string memory version,
+        address validatorConfiguration
+    ) CreatorTokenTransferValidator(
+        defaultOwner,
+        eoaRegistry_,
+        name,
+        version,
+        validatorConfiguration
+    ) {}
+
+    /**
+     * @notice Adds one or more accounts to a targetWhitelist.
+     *
+     * @dev Throws when the caller does not own the specified list.
+     * @dev Throws when the accounts array is empty.
+     *
+     * @dev <h4>Postconditions:</h4>
+     *      1. Accounts not previously in the list are added.
+     *      2. An `AddedAccountToList` event is emitted for each account that is newly added to the list.
+     *
+     * @param id       The id of the list.
+     * @param accounts The addresses of the accounts to add.
+     */
+    function addAccountsToTargetWhitelist(uint120 id, address[] calldata accounts) external {
+        _addAccountsToList(targetWhitelist[id], LIST_TYPE_TARGET_WHITELIST, id, accounts);
+    }
+
+        /**
+     * @notice Removes one or more accounts from a whitelist.
+     *
+     * @dev Throws when the caller does not own the specified list.
+     * @dev Throws when the accounts array is empty.
+     *
+     * @dev <h4>Postconditions:</h4>
+     *      1. Accounts previously in the list are removed.
+     *      2. A `RemovedAccountFromList` event is emitted for each account that is removed from the list.
+     *
+     * @param id       The id of the list.
+     * @param accounts The addresses of the accounts to remove.
+     */
+    function removeAccountsToTargetWhitelist(
+        uint120 id,
+        address[] calldata accounts
+    ) external {
+        _removeAccountsFromList(targetWhitelist[id], LIST_TYPE_TARGET_WHITELIST, id, accounts);
+    }
+
+    /**
+     * @notice Get whitelisted accounts by list id.
+     * @param  id The id of the list.
+     * @return An array of whitelisted accounts.
+     */
+    function getTargetWhitelistedAccounts(uint120 id) public view returns (address[] memory) {
+        return targetWhitelist[id].enumerableAccounts.values();
+    }
+
+    /**
+     * @notice Check if an account is whitelisted in a specified list.
+     * @param id       The id of the list.
+     * @param account  The address of the account to check.
+     * @return         True if the account is whitelisted in the specified list, false otherwise.
+     */
+    function isAccountTargetWhitelisted(uint120 id, address account) public view returns (bool) {
+        return targetWhitelist[id].nonEnumerableAccounts[account];
+    }
+
+    /*************************************************************************/
+    /*                       OVERRIDDEN VALIDATION LOGIC                     */
+    /*************************************************************************/
+  /**
+     * @notice Apply the collection transfer policy to a transfer operation of a creator token.
+     *
+     * @dev If the caller is self (Permit-C Processor) it means we have already applied operator validation in the
+     *      _beforeTransferFrom callback.  In this case, the security policy was already applied and the operator
+     *      that used the Permit-C processor passed the security policy check and transfer can be safely allowed.
+     *
+     * @dev The order of checking whitelisted accounts, authorized operator check and whitelisted codehashes
+     *      is very deliberate.  The order of operations is determined by the most frequently used settings that are
+     *      expected in the wild.
+     *
+     * @dev Throws when the collection has enabled account freezing mode and either the `from` or `to` addresses
+     *      are on the list of frozen accounts for the collection.
+     * @dev Throws when the collection is set to Level 9 - Soulbound Token.
+     * @dev Throws when the receiver has deployed code and isn't whitelisted, if ReceiverConstraints.NoCode is set
+     *      and the transfer is not approved by an authorizer for the collection.
+     * @dev Throws when the receiver has never verified a signature to prove they are an EOA and the receiver
+     *      isn't whitelisted, if the ReceiverConstraints.EOA is set and the transfer is not approved by an
+     *      authorizer for the collection..
+     * @dev Throws when `msg.sender` is blacklisted, if CallerConstraints.OperatorBlacklistEnableOTC is set, unless
+     *      `msg.sender` is also the `from` address or the transfer is approved by an authorizer for the collection.
+     * @dev Throws when `msg.sender` isn't whitelisted, if CallerConstraints.OperatorWhitelistEnableOTC is set, unless
+     *      `msg.sender` is also the `from` address or the transfer is approved by an authorizer for the collection.
+     * @dev Throws when neither `msg.sender` nor `from` are whitelisted, if
+     *      CallerConstraints.OperatorWhitelistDisableOTC is set and the transfer
+     *      is not approved by an authorizer for the collection.
+     *
+     * @dev <h4>Postconditions:</h4>
+     *      1. Transfer is allowed or denied based on the applied transfer policy.
+     *
+     * @param collection  The collection address of the token being transferred.
+     * @param caller      The address initiating the transfer.
+     * @param from        The address of the token owner.
+     * @param to          The address of the token receiver.
+     * @param tokenId     The token id being transferred.
+     *
+     * @return The selector value for an error if the transfer is not allowed, `SELECTOR_NO_ERROR` if the transfer is allowed.
+     */
+    function _validateTransfer(
+        function(address,address,uint256) internal view returns(bool) _callerAuthorizedParam,
+        address collection,
+        address caller,
+        address from,
+        address to,
+        uint256 tokenId
+    ) internal view override returns (bytes4,uint16) {
+
+
+        CollectionSecurityPolicyV3 storage collectionSecurityPolicy = collectionSecurityPolicies[collection];
+        uint120 listId = collectionSecurityPolicy.listId;
+        List storage targetWhitelist = targetWhitelist[listId];
+        // If the 'to' address is on the toWhitelist for this collection, bypass validation
+        if (targetWhitelist.nonEnumerableAccounts[to]) {
+            return (SELECTOR_NO_ERROR, DEFAULT_TOKEN_TYPE);
+        }
+
+        // Otherwise, use the parent contract's validation logic
+        return super._validateTransfer(_callerAuthorizedParam, collection, caller, from, to, tokenId );
+    }
+
+}

--- a/test/LoomValidator.t.sol
+++ b/test/LoomValidator.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import "./TransferValidator.t.sol";
+import "./TransferValidatorERC1155.t.sol";
 import {LoomValidator, LIST_TYPE_TARGET_WHITELIST} from "../src/utils/LoomValidator.sol";
 
-contract LoomValidatorTest is TransferValidatorTest {
+contract LoomValidatorTest is TransferValidatorTestERC1155 {
     LoomValidator public loomValidator;
 
     function setUp() public virtual override {
@@ -25,7 +25,7 @@ contract LoomValidatorTest is TransferValidatorTest {
     /*************************************************************************/
     /*                   TARGET WHITELIST MANAGEMENT TESTS                   */
     /*************************************************************************/
-    function testAddAccountsToTargetWhitelist(address listOwner, uint256 numAccountsToWhitelist, address[10] memory accounts) public {
+    function testAddAccountsToRecipientAllowlist(address listOwner, uint256 numAccountsToWhitelist, address[10] memory accounts) public {
         _sanitizeAddress(listOwner);
         numAccountsToWhitelist = bound(numAccountsToWhitelist, 1, 10);
 
@@ -55,21 +55,21 @@ contract LoomValidatorTest is TransferValidatorTest {
         }
 
         vm.prank(listOwner);
-        loomValidator.addAccountsToTargetWhitelist(listId, accountsToWhitelist);
+        loomValidator.addAccountsToRecipientAllowlist(listId, accountsToWhitelist);
 
         for (uint256 i = 0; i < numAccountsToWhitelist; i++) {
-            // assertTrue(loomValidator.isAccountTargetWhitelisted(listId, accountsToWhitelist[i]));
+          assertTrue(loomValidator.isAccountRecipientAllowlisted(listId, accountsToWhitelist[i]));
         }
 
-        // address[] memory whitelistedAccounts = loomValidator.getTargetWhitelistedAccounts(listId);
-        // assertEq(whitelistedAccounts.length, expectedNumAccountsWhitelisted);
+        address[] memory whitelistedAccounts = loomValidator.getRecipientAllowlistedAccounts(listId);
+        assertEq(whitelistedAccounts.length, expectedNumAccountsWhitelisted);
 
         for(uint256 i = 0; i < expectedNumAccountsWhitelisted; i++) {
-            // assertTrue(loomValidator.isAccountTargetWhitelisted(listId, accountsToWhitelist[i]));
+          assertTrue(loomValidator.isAccountRecipientAllowlisted(listId, accountsToWhitelist[i]));
         }
     }
 
-    function testRemoveAccountsFromTargetWhitelist(address listOwner, uint256 numAccountsToRemove, address[10] memory accounts) public {
+    function testRemoveAccountsFromRecipientAllowlist(address listOwner, uint256 numAccountsToRemove, address[10] memory accounts) public {
         _sanitizeAddress(listOwner);
         numAccountsToRemove = bound(numAccountsToRemove, 1, 10);
 
@@ -116,5 +116,4 @@ contract LoomValidatorTest is TransferValidatorTest {
         address[] memory whitelistedAccounts = validator.getWhitelistedAccounts(listId);
         assertEq(whitelistedAccounts.length, numPreWhitelistedAccounts - expectedNumAccountsRemoved);
     }
-
 }

--- a/test/LoomValidator.t.sol
+++ b/test/LoomValidator.t.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "./TransferValidator.t.sol";
+import {LoomValidator, LIST_TYPE_TARGET_WHITELIST} from "../src/utils/LoomValidator.sol";
+
+contract LoomValidatorTest is TransferValidatorTest {
+    LoomValidator public loomValidator;
+
+    function setUp() public virtual override {
+        super.setUp();
+
+        // Deploy LoomValidator instead of the regular CreatorTokenTransferValidator
+        loomValidator = new LoomValidator(
+            address(this),
+            address(eoaRegistry),
+            "LoomValidator",
+            "1.0.0",
+            address(validatorConfiguration)
+        );
+
+        validator = loomValidator;
+    }
+
+    /*************************************************************************/
+    /*                   TARGET WHITELIST MANAGEMENT TESTS                   */
+    /*************************************************************************/
+    function testAddAccountsToTargetWhitelist(address listOwner, uint256 numAccountsToWhitelist, address[10] memory accounts) public {
+        _sanitizeAddress(listOwner);
+        numAccountsToWhitelist = bound(numAccountsToWhitelist, 0, 10);
+
+        vm.prank(listOwner);
+        uint120 listId = validator.createList("test");
+
+        uint256 expectedNumAccountsWhitelisted = 0;
+        address[] memory accountsToWhitelist = new address[](numAccountsToWhitelist);
+        for (uint256 i = 0; i < numAccountsToWhitelist; i++) {
+            bool firstTimeAccount = true;
+            for (uint256 j = 0; j < i; j++) {
+                if (accountsToWhitelist[j] == accounts[i]) {
+                    firstTimeAccount = false;
+                    break;
+                }
+            }
+
+            accountsToWhitelist[i] = accounts[i];
+
+            if (firstTimeAccount) {
+                expectedNumAccountsWhitelisted++;
+                vm.expectEmit(true, true, true, true);
+                emit AddedAccountToList(LIST_TYPE_TARGET_WHITELIST, listId, accounts[i]);
+            }
+        }
+
+        vm.prank(listOwner);
+        loomValidator.addAccountsToTargetWhitelist(listId, accountsToWhitelist);
+
+        for (uint256 i = 0; i < numAccountsToWhitelist; i++) {
+            assertTrue(loomValidator.isAccountTargetWhitelisted(listId, accountsToWhitelist[i]));
+        }
+
+        address[] memory whitelistedAccounts = loomValidator.getTargetWhitelistedAccounts(listId);
+        assertEq(whitelistedAccounts.length, expectedNumAccountsWhitelisted);
+    }
+
+}


### PR DESCRIPTION
# Adds target recipient whitelisting to validator

This wraps limitbreak's validator to add the ability to allowlist a receiver contract, so that:

- users can send tokens directly to the raffle contract
- users can send their tokens to the bridge

While the contract compiles and deploys fine on foundry, copying the bytecode to [loomlock repo](https://github.com/abraxaslabs-io/loomlock/pull/127). However, the contract deployment failed on hardhat due to its size, so i ended up removing the view functions (`isAccountTargetWhitelisted` and `getTargetWhitelistedAccounts`).

I'm not too happy with the `targetWhitelist` name, so happy to change it if you have a better idea!

I also tried to test the actual transfer via foundry, but this is getting too deep into a tech i misunderstand(fuzzy addresses + leveraging )

Notes:

- updating to OZ 5 is messy, dependencies run deep in this family..
- limitbreak have no plans to upgrade to OZ5, rather, they plan on removing OZ dependency altogether